### PR TITLE
Add path to folder used for partner and pf data to check report

### DIFF
--- a/src/tgftools/checks.py
+++ b/src/tgftools/checks.py
@@ -96,8 +96,8 @@ class DatabaseChecks:
             doc=str(self.__doc__).replace("\n", ""),
             filenames={
                 "Model Results": str(self.db.model_results.path),
-                "Partner Data": "", #str(self.db.partner_data.path),
-                "PF Input Data": "", #str(self.db.pf_input_data.path),
+                "Partner Data": str(self.db.partner_data.path),
+                "PF Input Data": str(self.db.pf_input_data.path),
             },
         )
 


### PR DESCRIPTION
We have uncommented code so that the report on checks nonw contains the paths to the folder used for the various data sources. Moving forward these folders should contain date of the latest data being used, and the folder name updated. As data is updated, several folder for e.g model output will exist. 