### PR TITLE
Allow finding lower-edge of Convex Hull for CE Frontier

### DIFF
--- a/src/tgftools/find_cost_effective_frontier.py
+++ b/src/tgftools/find_cost_effective_frontier.py
@@ -48,6 +48,31 @@ def find_cost_effective_frontier(points: np.array, upper_edge: bool = True) -> n
     else:
         frontier = get_lower(points[hull.vertices])
 
+    # # PLots for checking
+    # lfrontier = get_lower(points[hull.vertices])
+    # ufrontier = get_upper(points[hull.vertices])
+    # import matplotlib.pyplot as plt
+    # pts_on_the_hull = points[hull.vertices]
+    # fig, ax = plt.subplots(ncols=1, figsize=(4, 4))
+    # ax.set_title('Frontier')
+    # ax.plot(points[:, 0], points[:, 1], '.', color='black', label='points')
+    # ax.plot(pts_on_the_hull[:, 0], pts_on_the_hull[:, 1],
+    #         'o', linestyle='-', mec='b', lw=1, markersize=10, color='none', label='hull')
+    # ax.plot(pts_on_the_hull[:, 0], pts_on_the_hull[:, 1],
+    #         linestyle='-', color='b')
+    # ax.plot(lfrontier[:, 0], lfrontier[:, 1],
+    #         '*', linestyle='-', mec='r', lw=1, markersize=10, color='none', label='lower frontier')
+    # ax.plot(lfrontier[:, 0], lfrontier[:, 1],
+    #         linestyle='-', color='r')
+    # ax.plot(ufrontier[:, 0], ufrontier[:, 1],
+    #         '*', linestyle='-', mec='g', lw=1, markersize=10, color='none', label='upper frontier')
+    # ax.plot(ufrontier[:, 0], ufrontier[:, 1],
+    #         linestyle='-', color='g')
+    # ax.set_xlabel('Cost')
+    # ax.set_ylabel('Value')
+    # ax.legend()
+    # fig.tight_layout()
+    # fig.show()
 
     return frontier
 

--- a/tests/test_find_cost_effective_frontier.py
+++ b/tests/test_find_cost_effective_frontier.py
@@ -5,8 +5,8 @@ from tgftools.find_cost_effective_frontier import find_cost_effective_frontier, 
 
 PLT_SHOW = False
 
-def test_find_cost_effective_frontier():
-    """Check that we can find the points on the cost-effectiveness frontier."""
+def test_find_cost_effective_frontier_when_maximising():
+    """Check that we can find the points on the cost-effectiveness frontier, when we have impact to be MAXIMISED"""
 
     for _ in range(10):
         # Generate some random points
@@ -52,3 +52,45 @@ def test_find_cost_effective_frontier():
             pd.Series(pts_on_the_frontier_from_ix[:, 0], pts_on_the_frontier_from_ix[:, 1]).sort_index(),
             pd.Series(pts_on_the_frontier[:, 0], pts_on_the_frontier[:, 1]).sort_index()
         )
+
+
+def test_find_cost_effective_frontier_when_minimising():
+    """Check that we can find the points on the cost-effectiveness frontier, when we have impact to be MINIMISED"""
+
+    for _ in range(10):
+        # Generate some random points
+        points = 10 * np.random.rand(15, 2)  # Random points in 2-D in the form (cost, impact)
+
+        # Get the frontier from the function `find_cost_effective_frontier`
+        pts_on_the_frontier = find_cost_effective_frontier(points, upper_edge=False)
+
+        # Cost of the first point is the lowest cost strategy
+        assert pts_on_the_frontier[0][0] == min(points[:, 0])
+
+        # Value of last point on the frontier is the *lowest* value point
+        assert pts_on_the_frontier[-1][1] == min(points[:, 1])
+
+        # Gradient between the successive points should be decreasing
+        list_of_gradients_between_pts_on_frontier = list()
+        for ix in range(0, len(pts_on_the_frontier) - 1):
+            list_of_gradients_between_pts_on_frontier.append(
+                (pts_on_the_frontier[ix + 1, 1] - pts_on_the_frontier[ix, 1])
+                / (pts_on_the_frontier[ix + 1, 0] - pts_on_the_frontier[ix, 0])
+            )
+        assert pd.Series(list_of_gradients_between_pts_on_frontier).abs().is_monotonic_decreasing
+
+        # Plot
+        if PLT_SHOW:
+            fig, ax = plt.subplots(ncols=1, figsize=(4, 4))
+            ax.set_title('Frontier')
+            ax.plot(points[:, 0], points[:, 1], '.', color='black')
+            ax.plot(pts_on_the_frontier[:, 0], pts_on_the_frontier[:, 1],
+                    'o', linestyle='-', mec='b', lw=1, markersize=10, color='none')
+            ax.plot(pts_on_the_frontier[:, 0], pts_on_the_frontier[:, 1],
+                    linestyle='-', color='b')
+            ax.set_xticks(range(12))
+            ax.set_yticks(range(12))
+            ax.set_xlabel('Cost')
+            ax.set_ylabel('Impact')
+            fig.tight_layout()
+            fig.show()


### PR DESCRIPTION
* give option to find the upper_edge or the lower_edge of the a group of points when finding the frontier.

* improve robustness of algorithm by relying on the order of veritces of the convexhull.

Diagnostic plot
<img width="394" alt="image" src="https://github.com/user-attachments/assets/6ad98a7b-8844-45a1-8f1e-42e3ecc44eaa">


This was raised, as the example of AFG for HIV revealed an unusual picture, which has now behaves as expected:

```python
import numpy as np
import pandas as pd
from matplotlib import pyplot as plt
from tgftools.find_cost_effective_frontier import which_points_on_frontier

"""AFG HIV debugging"""

cost = np.array([
    0,
    19608975.51,
    19799336.98,
    61651211.38,
    76460050.22,
    77423522.84,
    129113688.3,
    140875135.5,
])

cases = np.array([
    2684,
    1966,
    1635,
    1519,
    1413,
    1386,
    1381,
    788,
])

deaths = np.array([
    517,
    478,
    404,
    404,
    402,
    399,
    399,
    289,
])

# Create array in the format [(cost, value), ...]
obj = (cases / cases.max() + deaths / deaths.max())
points = pd.DataFrame([cost, obj]).T.values

pts_on_the_frontier = which_points_on_frontier(points, upper_edge=False)

#%% Plot

# OBJECTIVE
fig, ax = plt.subplots(ncols=1, figsize=(4, 4))
ax.set_title('Frontier')
ax.plot(cost, obj, '.', color='black')
ax.plot(cost[pts_on_the_frontier], obj[pts_on_the_frontier],
        'o', linestyle='-', mec='b', lw=1, markersize=10, color='none')
ax.plot(cost[pts_on_the_frontier], obj[pts_on_the_frontier],
        linestyle='-', color='b')
ax.set_xlabel('Cost')
ax.set_title('Objective Function')
fig.tight_layout()
fig.show()

# CASES
fig, ax = plt.subplots(ncols=1, figsize=(4, 4))
ax.set_title('Frontier')
ax.plot(cost, cases, '.', color='black')
ax.plot(cost[pts_on_the_frontier], cases[pts_on_the_frontier],
        'o', linestyle='-', mec='b', lw=1, markersize=10, color='none')
ax.plot(cost[pts_on_the_frontier], cases[pts_on_the_frontier],
        linestyle='-', color='b')
ax.set_xlabel('Cost')
ax.set_title('Cases')
fig.tight_layout()
fig.show()

# DEATHS
fig, ax = plt.subplots(ncols=1, figsize=(4, 4))
ax.set_title('Frontier')
ax.plot(cost, deaths, '.', color='black')
ax.plot(cost[pts_on_the_frontier], deaths[pts_on_the_frontier],
        'o', linestyle='-', mec='b', lw=1, markersize=10, color='none')
ax.plot(cost[pts_on_the_frontier], deaths[pts_on_the_frontier],
        linestyle='-', color='b')
ax.set_xlabel('Cost')
ax.set_title('Cases')
fig.tight_layout()
fig.show()
```
<img width="387" alt="image" src="https://github.com/user-attachments/assets/e6b18960-a302-4267-b6bc-af72950305eb">
<img width="387" alt="image" src="https://github.com/user-attachments/assets/8d9757de-0650-453d-85bd-ed80411b8cd7">
<img width="387" alt="image" src="https://github.com/user-attachments/assets/395cda97-50e7-44b3-a417-17cb71236b60">



